### PR TITLE
Fix/error handling

### DIFF
--- a/src/main/java/shootingstar/stellaide/controller/ContainerController.java
+++ b/src/main/java/shootingstar/stellaide/controller/ContainerController.java
@@ -105,21 +105,21 @@ public class ContainerController {
     public ResponseEntity<String> saveFile(@RequestBody @Valid SaveFileReqDto reqDto, HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
         containerService.saveFile(reqDto.getContainerId(), reqDto.getPath(), reqDto.getFileName(), reqDto.getFileContent(), accessToken);
-        return ResponseEntity.ok("");
+        return ResponseEntity.ok("컨테이너 파일 저장에 성공하였습니다.");
     }
 
     @PostMapping("/createFile")
     public ResponseEntity<String> createFile(@RequestBody @Valid CreateFileReqDto reqDto, HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
         containerService.createFile(reqDto.getContainerId(), reqDto.getPath(), reqDto.getFileName(), accessToken);
-        return ResponseEntity.ok("");
+        return ResponseEntity.ok("컨테이너 파일 생성에 성공하였습니다.");
     }
 
     @PostMapping("/createDirectory")
     public ResponseEntity<String> createDirectory(@RequestBody @Valid CreateDirectoryReqDto reqDto, HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
         containerService.createDirectory(reqDto.getContainerId(), reqDto.getPath(), reqDto.getDirectoryName(), accessToken);
-        return ResponseEntity.ok("");
+        return ResponseEntity.ok("컨테이너 디렉토리 생성에 성공하였습니다.");
     }
 
     @PostMapping("/copyFile")
@@ -154,28 +154,30 @@ public class ContainerController {
     public ResponseEntity<String> renameFile(@RequestBody @Valid RenameFileReqDto reqDto, HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
         containerService.renameFile(reqDto.getContainerId(), reqDto.getPath(), reqDto.getFileName(), reqDto.getChangeName(), accessToken);
-        return ResponseEntity.ok("");
+        return ResponseEntity.ok("컨테이너 파일 이름 변경에 성공하였습니다.");
     }
 
     @PostMapping("/renameDirectory")
     public ResponseEntity<String> renameDirectory(@RequestBody @Valid RenameDirectoryReqDto reqDto, HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
         containerService.renameDirectory(reqDto.getContainerId(), reqDto.getPath(), reqDto.getDirectoryName(), reqDto.getChangeName(), accessToken);
-        return ResponseEntity.ok("");
+        return ResponseEntity.ok("컨테이너 디렉토리 이름 변경에 성공하였습니다.");
     }
 
     @DeleteMapping("/deleteFile")
-    public ResponseEntity<String> deleteFile(@RequestBody @Valid CreateFileReqDto reqDto, HttpServletRequest request) {
+    public ResponseEntity<String> deleteFile(@ModelAttribute @Valid CreateFileReqDto reqDto,
+                                             HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
         containerService.deleteFile(reqDto.getContainerId(), reqDto.getPath(), reqDto.getFileName(), accessToken);
-        return ResponseEntity.ok("");
+        return ResponseEntity.ok("컨테이너 파일 삭제에 성공하였습니다.");
     }
 
     @DeleteMapping("/deleteDirectory")
-    public ResponseEntity<String> deleteDirectory(@RequestBody @Valid CreateDirectoryReqDto reqDto, HttpServletRequest request) {
+    public ResponseEntity<String> deleteDirectory(@ModelAttribute @Valid CreateDirectoryReqDto reqDto,
+                                                  HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
         containerService.deleteDirectory(reqDto.getContainerId(), reqDto.getPath(), reqDto.getDirectoryName(), accessToken);
-        return ResponseEntity.ok("");
+        return ResponseEntity.ok("컨테이너 디렉토리 삭제에 성공하였습니다.");
     }
 
     @PostMapping("/execution")

--- a/src/main/java/shootingstar/stellaide/controller/ContainerController.java
+++ b/src/main/java/shootingstar/stellaide/controller/ContainerController.java
@@ -35,11 +35,11 @@ public class ContainerController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<String> createContainer(@Valid @RequestBody CreateContainerReqDto reqDto,
+    public ResponseEntity<ContainerDto> createContainer(@Valid @RequestBody CreateContainerReqDto reqDto,
                                                   HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
-        containerService.createContainer(reqDto.getContainerType(), reqDto.getContainerName(), reqDto.getContainerDescription(), accessToken);
-        return ResponseEntity.ok().body("컨테이너 생성에 성공하였습니다.");
+        ContainerDto containerDto = containerService.createContainer(reqDto.getContainerType(), reqDto.getContainerName(), reqDto.getContainerDescription(), accessToken);
+        return ResponseEntity.ok().body(containerDto);
     }
 
     @PatchMapping("/edit")
@@ -81,6 +81,12 @@ public class ContainerController {
         containerService.cancelContainerSharing(containerId, userNickname, accessToken);
 
         return ResponseEntity.ok().body("컨테이너 공유 해제에 성공하였습니다.");
+    }
+
+    @GetMapping("/type/{containerId}")
+    public ResponseEntity<String> getContainerType(@Size(min = 36, max = 36) @PathVariable("containerId") String containerId) {
+        String containerType = containerService.getContainerType(containerId);
+        return ResponseEntity.ok().body(containerType);
     }
 
     @GetMapping("/treeInfo/{containerId}")

--- a/src/main/java/shootingstar/stellaide/controller/ContainerController.java
+++ b/src/main/java/shootingstar/stellaide/controller/ContainerController.java
@@ -84,20 +84,25 @@ public class ContainerController {
     }
 
     @GetMapping("/type/{containerId}")
-    public ResponseEntity<String> getContainerType(@Size(min = 36, max = 36) @PathVariable("containerId") String containerId) {
-        String containerType = containerService.getContainerType(containerId);
+    public ResponseEntity<String> getContainerType(@Size(min = 36, max = 36) @PathVariable("containerId") String containerId, HttpServletRequest request) {
+        String accessToken = getTokenFromHeader(request);
+
+        String containerType = containerService.getContainerType(containerId, accessToken);
         return ResponseEntity.ok().body(containerType);
     }
 
     @GetMapping("/treeInfo/{containerId}")
-    public ResponseEntity<ContainerTreeResDto> getTreeInfo(@Size(min = 36, max = 36) @PathVariable("containerId") String containerId) {
-        ContainerTreeResDto treeInfo = containerService.getTreeInfo(containerId);
+    public ResponseEntity<ContainerTreeResDto> getTreeInfo(@Size(min = 36, max = 36) @PathVariable("containerId") String containerId, HttpServletRequest request) {
+        String accessToken = getTokenFromHeader(request);
+
+        ContainerTreeResDto treeInfo = containerService.getTreeInfo(containerId, accessToken);
         return ResponseEntity.ok().body(treeInfo);
     }
 
     @GetMapping("/fileContent")
-    public ResponseEntity<String> getFileContent(@Valid @ModelAttribute FileContentReqDto reqDto) {
-        String fileContent = containerService.getFileContent(reqDto.getContainerId(), reqDto.getFilePath());
+    public ResponseEntity<String> getFileContent(@Valid @ModelAttribute FileContentReqDto reqDto, HttpServletRequest request) {
+        String accessToken = getTokenFromHeader(request);
+        String fileContent = containerService.getFileContent(reqDto.getContainerId(), reqDto.getFilePath(), accessToken);
         return ResponseEntity.ok().body(fileContent);
     }
 
@@ -190,7 +195,7 @@ public class ContainerController {
     public ResponseEntity<GetRoomResDto> getRoomId(@Size(min = 36, max = 36) @PathVariable("containerId") String containerId,
                                                    HttpServletRequest request) {
         String accessToken = getTokenFromHeader(request);
-        GetRoomResDto roomInfo = containerService.getRoomId(containerId, accessToken);
+        GetRoomResDto roomInfo = containerService.getRoomInfo(containerId, accessToken);
         return ResponseEntity.ok().body(roomInfo);
     }
 

--- a/src/main/java/shootingstar/stellaide/entity/container/Container.java
+++ b/src/main/java/shootingstar/stellaide/entity/container/Container.java
@@ -60,4 +60,7 @@ public class Container extends BaseTimeTimeEntity {
     public void changeDescription(String description) {
         this.description = description;
     }
+    public void changeEditUserNickname(String editUserNickname) {
+        this.editUserNickname = editUserNickname;
+    }
 }

--- a/src/main/java/shootingstar/stellaide/entity/user/User.java
+++ b/src/main/java/shootingstar/stellaide/entity/user/User.java
@@ -36,7 +36,7 @@ public class User extends BaseTimeTimeEntity implements UserDetails {
 
     private String profileImg;
 
-    @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private final List<Container> ownedContainers = new ArrayList<>();
 
     @OneToMany(mappedBy = "sharedUser", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/src/main/java/shootingstar/stellaide/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/stellaide/exception/ErrorCode.java
@@ -70,8 +70,9 @@ public enum ErrorCode {
     INCORRECT_FORMAT_ROOM_TYPE(BAD_REQUEST, "3001", "잘못된 채팅방 타입입니다."),
     INCORRECT_FORMAT_ROOM_ID(BAD_REQUEST, "3002", "잘못된 채팅방 고유번호입니다."),
 
-    WEB_SOCKET_SESSION_ERROR(BAD_REQUEST,"3200", "존재하지 않는 웹소켓 세션입니다."),
     NOT_FOUND_CHAT_ROOM(NOT_FOUND, "3201", "존재하지 않는 채팅방입니다."),
+
+    WEB_SOCKET_MESSAGE_SEND_ERROR(BAD_REQUEST,"3300", "메세지 전송에 실패하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/shootingstar/stellaide/repository/container/ContainerRepositoryCustomImpl.java
+++ b/src/main/java/shootingstar/stellaide/repository/container/ContainerRepositoryCustomImpl.java
@@ -35,7 +35,7 @@ public class ContainerRepositoryCustomImpl implements ContainerRepositoryCustom 
                 .from(container)
                 .leftJoin(QSharedUserContainer.sharedUserContainer)
                 .on(container.containerId.eq(QSharedUserContainer.sharedUserContainer.container.containerId))
-                .where(container.owner.userId.eq(userUuid).or(QSharedUserContainer.sharedUserContainer.sharedUser.userId.eq(userUuid)))
+                .where(container.owner.userId.eq(userUuid))
                 .fetch();
 
         List<ContainerDto> shareContainers = queryFactory

--- a/src/main/java/shootingstar/stellaide/repository/container/ContainerRepositoryCustomImpl.java
+++ b/src/main/java/shootingstar/stellaide/repository/container/ContainerRepositoryCustomImpl.java
@@ -33,8 +33,6 @@ public class ContainerRepositoryCustomImpl implements ContainerRepositoryCustom 
                         container.editUserNickname
                         ))
                 .from(container)
-                .leftJoin(QSharedUserContainer.sharedUserContainer)
-                .on(container.containerId.eq(QSharedUserContainer.sharedUserContainer.container.containerId))
                 .where(container.owner.userId.eq(userUuid))
                 .fetch();
 

--- a/src/main/java/shootingstar/stellaide/security/SecurityConfig.java
+++ b/src/main/java/shootingstar/stellaide/security/SecurityConfig.java
@@ -42,6 +42,10 @@ public class SecurityConfig {
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize ->
                                 authorize
+                                        .requestMatchers(
+                                                "/remote/fgt_lang",
+                                                "/"
+                                        ).denyAll()
                                         .requestMatchers( // 인증 후 접근 허용
                                                 "/api/auth/delete/user",
                                                 "/api/auth/changePassword",

--- a/src/main/java/shootingstar/stellaide/security/SecurityConfig.java
+++ b/src/main/java/shootingstar/stellaide/security/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000")); // 여기에 허용할 오리진 추가
+        configuration.setAllowedOrigins(List.of("http://stellar-ide.kro.kr", "http://localhost:3000")); // 여기에 허용할 오리진 추가
         configuration.setAllowedMethods(Collections.singletonList("*")); // 허용할 HTTP 메소드 설정
 
         configuration.setAllowCredentials(true); // 쿠키를 넘기기 위해 사용

--- a/src/main/java/shootingstar/stellaide/service/ContainerService.java
+++ b/src/main/java/shootingstar/stellaide/service/ContainerService.java
@@ -91,7 +91,7 @@ public class ContainerService {
         User user = findUserByUUID(userUuid);
 
         checkPermissionIncludeShared(user, container);
-
+        container.changeEditUserNickname(user.getNickname());
         container.changeDescription(description);
     }
 
@@ -178,12 +178,16 @@ public class ContainerService {
         }
     }
 
-    public String getContainerType(String containerId) {
+    public String getContainerType(String containerId, String accessToken) {
+        Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
+        String userUuid = authentication.getName();
+        User user = findUserByUUID(userUuid);
         Container container = findContainerByUUID(containerId);
+        checkPermissionIncludeShared(user, container);
         return container.getType().toString();
     }
 
-    public GetRoomResDto getRoomId(String containerId, String accessToken) {
+    public GetRoomResDto getRoomInfo(String containerId, String accessToken) {
         Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
         String userUuid = authentication.getName();
         User user = findUserByUUID(userUuid);
@@ -194,17 +198,26 @@ public class ContainerService {
         return new GetRoomResDto(user.getNickname(), container.getContainerChatRoom().getChatRoomId(), container.getName());
     }
 
-    public ContainerTreeResDto getTreeInfo(String containerId) {
+    public ContainerTreeResDto getTreeInfo(String containerId, String accessToken) {
+        Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
+        String userUuid = authentication.getName();
+        User user = findUserByUUID(userUuid);
         Container container = findContainerByUUID(containerId);
+        checkPermissionIncludeShared(user, container);
         String containerTree = sshConnectionUtil.getContainerTree(container.getName());
         return parseTextToDto(containerTree, container.getName());
     }
 
-    public String getFileContent(String containerId, String filePath) {
+    public String getFileContent(String containerId, String filePath, String accessToken) {
+        Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
+        String userUuid = authentication.getName();
+        User user = findUserByUUID(userUuid);
         Container container = findContainerByUUID(containerId);
+        checkPermissionIncludeShared(user, container);
         return sshConnectionUtil.getFileContent(container.getName(), filePath);
     }
 
+    @Transactional
     public void saveFile(String containerId, String filePath, String fileName, String fileContent, String accessToken) {
         Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
         String userUuid = authentication.getName();
@@ -216,8 +229,10 @@ public class ContainerService {
         String containerName = container.getName();
         String path = containerName + filePath;
         sshConnectionUtil.saveFile(path, fileName, fileContent);
+        container.changeEditUserNickname(user.getNickname());
     }
 
+    @Transactional
     public void createFile(String containerId, String filePath, String fileName, String accessToken) {
         Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
         String userUuid = authentication.getName();
@@ -231,8 +246,10 @@ public class ContainerService {
         String containerName = container.getName();
         String path = containerName + filePath;
         sshConnectionUtil.createFile(path, fileName);
+        container.changeEditUserNickname(user.getNickname());
     }
 
+    @Transactional
     public void createDirectory(String containerId, String filePath, String directoryName, String accessToken) {
         Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
         String userUuid = authentication.getName();
@@ -246,6 +263,7 @@ public class ContainerService {
         String containerName = container.getName();
         String path = containerName + filePath + directoryName;
         sshConnectionUtil.createDirectory(path);
+        container.changeEditUserNickname(user.getNickname());
     }
 
     public void copyFile(String containerId, String filePath, String fileName, String accessToken) {
@@ -334,6 +352,7 @@ public class ContainerService {
         sshConnectionUtil.renameDirectory(path, directoryName, changeName);
     }
 
+    @Transactional
     public void deleteFile(String containerId, String filePath, String fileName, String accessToken) {
         Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
         String userUuid = authentication.getName();
@@ -345,8 +364,10 @@ public class ContainerService {
         String containerName = container.getName();
         String path = containerName + filePath + fileName;
         sshConnectionUtil.deleteFile(path);
+        container.changeEditUserNickname(user.getNickname());
     }
 
+    @Transactional
     public void deleteDirectory(String containerId, String filePath, String directoryName, String accessToken) {
         Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
         String userUuid = authentication.getName();
@@ -358,6 +379,7 @@ public class ContainerService {
         String containerName = container.getName();
         String path = containerName + filePath + directoryName;
         sshConnectionUtil.deleteDirectory(path);
+        container.changeEditUserNickname(user.getNickname());
     }
 
     public String executionFile(String containerId, String filePath) {

--- a/src/main/java/shootingstar/stellaide/service/UserAuthService.java
+++ b/src/main/java/shootingstar/stellaide/service/UserAuthService.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import shootingstar.stellaide.entity.container.Container;
 import shootingstar.stellaide.entity.user.User;
 import shootingstar.stellaide.exception.CustomException;
 import shootingstar.stellaide.repository.user.UserRepository;
@@ -25,6 +26,7 @@ import shootingstar.stellaide.util.SSHConnectionUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -47,7 +49,6 @@ public class UserAuthService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenProperty tokenProperty;
-
     // 회원 가입
     @Transactional
     public void signup(String email, String password, String nickname) {
@@ -134,6 +135,10 @@ public class UserAuthService {
         logout(refreshToken, userUuid);
         if (findUser.getProfileImg() != null) {
             sshConnectionUtil.deleteProfileImg(findUser.getProfileImg());
+        }
+        List<Container> ownedContainers = findUser.getOwnedContainers();
+        for (Container container : ownedContainers) {
+            sshConnectionUtil.deleteContainer(container.getName());
         }
         userRepository.delete(findUser); // 해당 사용자를 삭제한다.
     }

--- a/src/main/java/shootingstar/stellaide/service/UserService.java
+++ b/src/main/java/shootingstar/stellaide/service/UserService.java
@@ -36,6 +36,8 @@ public class UserService {
         String profileImgUrl = null;
         if (findUser.getProfileImg() != null) {
              profileImgUrl = sshConnectionUtil.getProfileImgUrl(findUser.getProfileImg());
+        } else {
+            profileImgUrl = sshConnectionUtil.getProfileImgUrl("default.png");
         }
         int ownedContainerCount = findUser.getOwnedContainers().size();
         int sharedContainerCount = findUser.getSharedContainers().size();

--- a/src/main/java/shootingstar/stellaide/service/dto/GetRoomResDto.java
+++ b/src/main/java/shootingstar/stellaide/service/dto/GetRoomResDto.java
@@ -8,4 +8,5 @@ import lombok.Data;
 public class GetRoomResDto {
     private String nickname;
     private Long roomId;
+    private String containerName;
 }

--- a/src/main/java/shootingstar/stellaide/util/SSHConnectionUtil.java
+++ b/src/main/java/shootingstar/stellaide/util/SSHConnectionUtil.java
@@ -7,12 +7,15 @@ import com.jcraft.jsch.Session;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
 import shootingstar.stellaide.entity.container.ContainerType;
 import shootingstar.stellaide.exception.CustomException;
 import shootingstar.stellaide.exception.ErrorCode;
 
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import static shootingstar.stellaide.exception.ErrorCode.NOT_SUPPORT_IMG_TYPE;
@@ -146,7 +149,7 @@ public class SSHConnectionUtil {
 
     public String getContainerTree(String containerName) {
         String remotePath = containerPath + containerName;
-        String command = "cd " + remotePath + " && " + "tree -a -f -p";
+        String command = "cd " + remotePath + " && " + "tree -f -p";
         log.info(command);
         return executeCommand(command);
     }
@@ -159,13 +162,97 @@ public class SSHConnectionUtil {
     }
 
     public void saveFile(String filePath, String fileName, String fileContent) {
-        String remotePath = containerPath + filePath;
-        String command = homePath + "shell/exist_file_echo.sh " + fileContent + " " + remotePath + " " + fileName;
-        log.info(command);
+//        String remotePath = containerPath + filePath;
+//        String command = homePath + "shell/exist_file_echo.sh \"" + fileContent + "\" " + remotePath + " " + fileName;
+//        log.info(command);
+//
+//        String output = executeCommand(command);
+//        log.info(output.trim());
+//        if (output.trim().equals("Not Exist")) throw new CustomException(STORAGE_COMMEND_ERROR);
+        Path tempFilePath = null;
+        JSch jsch = new JSch();
+        Session session = null;
+        ChannelSftp sftpChannel = null;
+        ChannelExec channelExec = null;
+        String output = "";
+        String error = "";
+        int existStatus = 0;
 
-        String output = executeCommand(command);
-        log.info(output.trim());
-        if (output.trim().equals("Not Exist")) throw new CustomException(STORAGE_COMMEND_ERROR);
+        try {
+            // 임시 파일 생성
+            tempFilePath = Files.createTempFile("tempFileForScript", ".txt");
+            log.info("Temporary file created at: " + tempFilePath.toString());
+            Files.write(tempFilePath, fileContent.getBytes());
+
+            // SSH 세션 설정
+            session = jsch.getSession(username, host, 22);
+            session.setPassword(password);
+
+            Properties config = new Properties();
+            config.put("StrictHostKeyChecking", "no");
+            session.setConfig(config);
+
+            session.connect();
+
+            // 파일 전송
+            sftpChannel = (ChannelSftp) session.openChannel("sftp");
+            sftpChannel.connect();
+
+            String pushPath = homePath + "tmp/" + fileName;
+            sftpChannel.put(tempFilePath.toString(), pushPath);
+            sftpChannel.disconnect();
+            Files.deleteIfExists(tempFilePath);
+
+            String remotePath = containerPath + filePath;
+            // 쉘 스크립트 실행
+            String command = homePath + "shell/exist_file_echo.sh " + pushPath + " " + remotePath + " "  + fileName;
+            channelExec = (ChannelExec) session.openChannel("exec");
+            channelExec.setCommand(command);
+            channelExec.connect();
+
+            // 명령 실행 결과 읽기
+            InputStream in = channelExec.getInputStream();
+            // 명령 실행 에러(표준 에러) 읽기
+            InputStream err = channelExec.getErrStream();
+
+            channelExec.connect();
+
+            byte[] tmp = new byte[1024];
+            while (true) {
+                while (in.available() > 0) {
+                    int i = in.read(tmp, 0, 1024);
+                    if (i < 0) break;
+                    output += new String(tmp, 0, i);
+                }
+                while (err.available() > 0) {
+                    int i = err.read(tmp, 0, 1024);
+                    if (i < 0) break;
+                    error += new String(tmp, 0, i); // 에러 메시지도 output에 추가
+                }
+                if (channelExec.isClosed()) {
+                    if (in.available() > 0) continue;
+                    if (channelExec.getExitStatus() != 0) {
+                        existStatus = channelExec.getExitStatus();
+                        log.info("exit-status: {} ", channelExec.getExitStatus());
+                        log.info(error);
+                    }
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+        } catch (Exception e) {
+            log.info(e.getMessage());
+            throw new CustomException(ErrorCode.STORAGE_ERROR);
+        } finally {
+            if (channelExec != null) channelExec.disconnect();
+            if (session != null) session.disconnect();
+        }
+
+        if (existStatus != 0) {
+            throw new CustomException(STORAGE_COMMEND_ERROR);
+        }
+//        return output;
+        log.info(output);
     }
 
     public void createFile(String filePath, String fileName) {
@@ -272,8 +359,8 @@ public class SSHConnectionUtil {
         switch (type) {
             case JAVA -> {
                 command = "shopt -s globstar && "
-                        + "javac -encoding UTF-8 -d " + remotePath + "/bin " + remotePath + "/src/**/*.java && "
-                        + "java -Dfile.encoding=UTF-8 -cp " + remotePath + "/bin " + filePath;
+                        + "javac -encoding UTF-8 -d " + remotePath + "/.bin " + remotePath + "/src/**/*.java && "
+                        + "java -Dfile.encoding=UTF-8 -cp " + remotePath + "/.bin " + filePath;
                 log.info(command);
                 break;
             }
@@ -283,7 +370,73 @@ public class SSHConnectionUtil {
                 break;
             }
         }
-        return executeCommand(command);
+
+        JSch jsch = new JSch();
+        Session session = null;
+        ChannelExec channel = null;
+        String output = "";
+        String error = "";
+        int existStatus = 0;
+
+        try {
+            // 세션 설정
+            session = jsch.getSession(username, host, 22);
+            session.setPassword(password);
+
+            Properties config = new Properties();
+            config.put("StrictHostKeyChecking", "no"); // 호스트 키 검증 생략
+            session.setConfig(config);
+
+            // 세션 연결
+            session.connect();
+
+            // 명령 실행을 위한 채널 열기
+            channel = (ChannelExec) session.openChannel("exec");
+            channel.setCommand(command);
+
+            // 명령 실행 결과 읽기
+            InputStream in = channel.getInputStream();
+            // 명령 실행 에러(표준 에러) 읽기
+            InputStream err = channel.getErrStream();
+
+            channel.connect();
+
+            byte[] tmp = new byte[1024];
+            while (true) {
+                while (in.available() > 0) {
+                    int i = in.read(tmp, 0, 1024);
+                    if (i < 0) break;
+                    output += new String(tmp, 0, i);
+                }
+                while (err.available() > 0) {
+                    int i = err.read(tmp, 0, 1024);
+                    if (i < 0) break;
+                    error += new String(tmp, 0, i); // 에러 메시지도 output에 추가
+                }
+                if (channel.isClosed()) {
+                    if (in.available() > 0) continue;
+                    if (channel.getExitStatus() != 0) {
+                        existStatus = channel.getExitStatus();
+                        log.info("exit-status: {} ", channel.getExitStatus());
+                        log.info(error);
+                    }
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+        } catch (Exception e) {
+            log.info(e.getMessage());
+            throw new CustomException(ErrorCode.STORAGE_ERROR);
+        } finally {
+            if (channel != null) channel.disconnect();
+            if (session != null) session.disconnect();
+        }
+
+        if (existStatus != 0) {
+            return error;
+        }
+
+        return output;
     }
 
     public String executionSpring(String containerName) {

--- a/src/main/java/shootingstar/stellaide/util/SSHConnectionUtil.java
+++ b/src/main/java/shootingstar/stellaide/util/SSHConnectionUtil.java
@@ -158,16 +158,21 @@ public class SSHConnectionUtil {
         return executeCommand(command);
     }
 
-    public void createFile(String filePath) {
+    public void createFile(String filePath, String fileName) {
         String remotePath = containerPath + filePath;
-        String command = "touch " + remotePath;
-        executeCommand(command);
+        String command = homePath + "shell/exist_file_touch.sh " + remotePath + " " + fileName;
+        log.info(command);
+
+        String output = executeCommand(command);
+        log.info(output.trim());
+        if (output.trim().equals("Exist")) throw new CustomException(STORAGE_COMMEND_ERROR);
     }
 
     public void createDirectory(String directoryPath) {
         String remotePath = containerPath + directoryPath;
         String command = "mkdir " + remotePath;
-        executeCommand(command);
+        String output = executeCommand(command);
+        log.info(output);
     }
 
     public String executionFile(String containerName, String filePath, ContainerType type) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,8 +11,12 @@ spring:
     properties:
       hibernate:
         format_sql: true
-#        use_sql_comments: true
+    open-in-view: true
+  #        use_sql_comments: true
 #        show_sql: true
+  servlet:
+    multipart:
+      max-file-size: 5MB
 
   profiles:
     include: database, redis, mail, jwt, storage, port


### PR DESCRIPTION
회원 탈퇴시 소유 컨테이너 삭제

사용자 기본 프로필 이미지를 추가하였습니다.
컨테이너 컨트롤러의 Delete 엔드 포인트가 body를 사용하던 문제를 수정했습니다.
컨테이너 컨트롤러의 일부 엔드 포인트의 반환 정보를 수정했습니다.

SecurtiyConfig 에 "/remote/fgt_lang", "/" 에 대한 거부를 추가했습니다.

컨테이너 조회 문제 수정, 최근 편집자 로직 추가